### PR TITLE
Add Commune MCP to Communication section

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ MCP servers related to Communication
 - [Email](https://github.com/Shy2593666979/mcp-server-email) - This server enables users to send emails through various email providers, including Gmail, Outlook, Yahoo, Sina, Sohu, 126, 163, and QQ Mail. It also supports attaching files from specified directories, making it easy to upload attachments along with the email content
 - [Discord](https://github.com/v-3/discordmcp) - A MCP server to connect to Discord guilds through a bot and read and write messages in channels
 - [Gmail](https://github.com/Mito-Ya-Baraka/gmail-mcp-server) - A MCP server to interact with Gmail API
+- [Commune MCP](https://github.com/commune-sh/commune-mcp) - Email infrastructure built for AI agents — provision inboxes programmatically, send and receive email, manage threads, custom domains, attachments, structured extraction on inbound mail, and SMS
 
 ## Customer Data Platforms
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ MCP servers related to Communication
 - [Email](https://github.com/Shy2593666979/mcp-server-email) - This server enables users to send emails through various email providers, including Gmail, Outlook, Yahoo, Sina, Sohu, 126, 163, and QQ Mail. It also supports attaching files from specified directories, making it easy to upload attachments along with the email content
 - [Discord](https://github.com/v-3/discordmcp) - A MCP server to connect to Discord guilds through a bot and read and write messages in channels
 - [Gmail](https://github.com/Mito-Ya-Baraka/gmail-mcp-server) - A MCP server to interact with Gmail API
-- [Commune MCP](https://github.com/commune-sh/commune-mcp) - Email infrastructure built for AI agents — provision inboxes programmatically, send and receive email, manage threads, custom domains, attachments, structured extraction on inbound mail, and SMS
+- [Commune MCP](https://github.com/shanjairaj7/commune) - Email infrastructure built for AI agents — provision inboxes programmatically, send and receive email, manage threads, custom domains, attachments, structured extraction on inbound mail, and SMS
 
 ## Customer Data Platforms
 
@@ -442,3 +442,4 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+


### PR DESCRIPTION
Adding Commune MCP to the Communication section.

The existing email entries here are mostly wrappers around Gmail or generic SMTP senders. Commune is different — it's email infrastructure designed specifically for agents, not humans. The practical difference: you can create a new inbox on demand (per customer, per workflow, per agent session), inbound emails come back as structured data rather than raw text the agent has to parse, and thread tracking works properly across concurrent conversations.

It's the difference between "agent can send an email" and "agent has a real, manageable email identity."

`uvx commune-mcp` — installs in seconds, no global dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Commune MCP entry to the Communication section describing email infrastructure for AI agents: programmatic inbox provisioning, send/receive messaging, thread management, custom domains, attachments, structured extraction of inbound mail, and SMS capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->